### PR TITLE
Records

### DIFF
--- a/dune
+++ b/dune
@@ -1,3 +1,7 @@
+(env
+  (dev
+    (flags (:standard -w -33))))
+
 (rule
  (targets GLib-2.0.xml)
  (action (run g-ir-generate -o GLib-2.0.xml %{env:PREFIX=/usr/local}/girepository-1.0/GLib-2.0.typelib))
@@ -38,7 +42,7 @@
  (name ocamlgtk)
  (wrapped false)
  ; (deps (filename Gtk.ml) (filename GObject.ml) (filename gobject0.ml) (filename Gio.ml Gdk)
- (modules Gtk GObject gobject0 Gio Gdk)
+ (modules Gtk GObject gobject0 Gio Gdk GLib)
  (flags :standard -no-strict-sequence -w -7)
  (c_library_flags (:include gtk4-libs.sexp))
  (foreign_stubs

--- a/examples/dune
+++ b/examples/dune
@@ -18,3 +18,8 @@
  (modules textiter_raw)
  (libraries ocamlgtk)
 )
+
+(executable (name textiter)
+ (modules textiter)
+ (libraries ocamlgtk)
+)

--- a/examples/dune
+++ b/examples/dune
@@ -13,3 +13,8 @@
  (modules get_set)
  (libraries ocamlgtk)
 )
+
+(executable (name textiter_raw)
+ (modules textiter_raw)
+ (libraries ocamlgtk)
+)

--- a/examples/textiter.ml
+++ b/examples/textiter.ml
@@ -1,0 +1,21 @@
+let () =
+  let app = Gtk.application "org.gtk.example" Gio.ApplicationFlags.flags_none in
+  ignore @@ app#signal_connect_activate begin fun () ->
+    let window = Gtk.application_window app in
+    window#set_title "Window";
+    window#set_default_size 200 200;
+    window#show;
+
+    let textView = Gtk.text_view () in
+    let textBuffer = textView#get_buffer in (* TODO: Check safety: get_buffer does not increment the reference count on the buffer! *)
+    textBuffer#set_text "Hello, world!" (-1);
+    let startIter = textBuffer#get_start_iter in
+    let iter = textBuffer#get_start_iter in
+    ignore @@ iter#forward_chars 5;
+    textBuffer#delete startIter iter;
+    textBuffer#insert_markup startIter "<span color=\"blue\">Bye</span>" (-1);
+
+    window#set_child (textView :> Gtk.widget);
+  end;
+  let status = app#run Sys.argv in
+  exit status

--- a/examples/textiter_raw.ml
+++ b/examples/textiter_raw.ml
@@ -1,0 +1,25 @@
+let () =
+  let app = Gtk.Application_._new "org.gtk.example" Gio.ApplicationFlags.flags_none  in
+  ignore @@ Gio.Application_.signal_connect_activate app begin fun () ->
+
+    let window = Gtk.ApplicationWindow_._new app in
+    Gtk.Window_.set_title window "Window";
+    Gtk.Window_.set_default_size window 200 200;
+
+    let textView = Gtk.TextView_._new () in
+    let textBuffer = Gtk.TextView_.get_buffer textView in (* TODO: Check safety: get_buffer does not increment the reference count on the buffer! *)
+    Gtk.TextBuffer_.set_text textBuffer "Hello, world!" 13; (* https://gitlab.gnome.org/GNOME/gtk/-/issues/5546 *)
+    let startIter = Gtk.TextIter_.alloc_uninit_UNSAFE () in
+    Gtk.TextBuffer_.get_start_iter textBuffer startIter;
+    let iter = Gtk.TextIter_.alloc_uninit_UNSAFE () in
+    Gtk.TextIter_.assign iter startIter;
+    ignore @@ Gtk.TextIter_.forward_chars iter 5; (* After "Hello" *)
+    Gtk.TextBuffer_.delete textBuffer startIter iter;
+    Gtk.TextBuffer_.insert_markup textBuffer startIter "<span color=\"blue\">Bye</span>" (-1); (* https://gitlab.gnome.org/GNOME/gtk/-/issues/5547 *)
+
+    Gtk.Window_.set_child window textView;
+    let _ = Gtk.Window_.signal_connect_close_request window (fun () -> exit 0) in
+    Gtk.Widget_.show window
+  end;
+  let status = Gio.Application_.run app Sys.argv in
+  exit status

--- a/generate_bindings.py
+++ b/generate_bindings.py
@@ -227,6 +227,7 @@ class ElementType:
     allow_none: bool
     transfer_ownership: Optional[str]
     direction: Optional[str]
+    caller_allocates: Optional[str]
 
     @property
     def to_str(self):
@@ -250,8 +251,9 @@ class ElementType:
         allow_none = elem.get('allow-none', "0") == "1"
         transfer_ownership = elem.get('transfer-ownership', None)
         direction = elem.get('direction', None)
+        caller_allocates = elem.get('caller-allocates', None)
         typename = typ.attrib['name']
-        return cls(typename, array, allow_none, transfer_ownership, direction)
+        return cls(typename, array, allow_none, transfer_ownership, direction, caller_allocates)
 
 @dataclass
 class Method:
@@ -681,8 +683,8 @@ class MethodParser(BaseMethodParser):
         if t.transfer_ownership != 'none':
             self.print_skip('missing transfer-ownership="none" attribute for parameter %s' % ps_name)
             return False
-        if t.direction is not None:
-            self.print_skip('explicit "direction" attribute for parameter %s not yet supported' % ps_name)
+        if not (t.direction is None and t.caller_allocates is None or t.direction == 'out' and t.caller_allocates == '1'):
+            self.print_skip('Parameter %s: unexpected value for "direction" or "caller_allocates"' % ps_name)
             return False
         return True
 


### PR DESCRIPTION
- Refactoring: extract compute_ancestors
- Rename methods that clash with inherited methods
- Records (such as TextIter)
- Allow out parameters
- Fix some compiler warnings
- Generate (unsafe) alloc functions for records
