### PR TITLE
properties

### DIFF
--- a/examples/textiter.ml
+++ b/examples/textiter.ml
@@ -9,11 +9,15 @@ let () =
     let textView = Gtk.text_view () in
     let textBuffer = textView#get_buffer in (* TODO: Check safety: get_buffer does not increment the reference count on the buffer! *)
     textBuffer#set_text "Hello, world!" (-1);
-    let startIter = textBuffer#get_start_iter in
     let iter = textBuffer#get_start_iter in
     ignore @@ iter#forward_chars 5;
-    textBuffer#delete startIter iter;
-    textBuffer#insert_markup startIter "<span color=\"blue\">Bye</span>" (-1);
+    textBuffer#delete textBuffer#get_start_iter iter;
+    textBuffer#insert_markup iter "<span color=\"blue\">Bye</span>" (-1);
+
+    let tag = Gtk.text_tag "red" in
+    tag#set_foreground "red";
+    ignore @@ textBuffer#get_tag_table#add tag;
+    textBuffer#apply_tag tag iter textBuffer#get_end_iter;
 
     window#set_child (textView :> Gtk.widget);
   end;

--- a/examples/textiter.ml
+++ b/examples/textiter.ml
@@ -16,6 +16,10 @@ let () =
 
     let tag = Gtk.text_tag "red" in
     tag#set_foreground "red";
+    tag#set_editable false;
+    tag#set_weight 900; (* https://docs.gtk.org/Pango/enum.Weight.html *)
+    tag#set_line_height 3.0;
+    tag#set_scale 1.5;
     ignore @@ textBuffer#get_tag_table#add tag;
     textBuffer#apply_tag tag iter textBuffer#get_end_iter;
 


### PR DESCRIPTION
- Refactoring: extract compute_ancestors
- Rename methods that clash with inherited methods
- Records (such as TextIter)
- Allow out parameters
- Fix some compiler warnings
- Generate (unsafe) alloc functions for records
- In OO layer, return out params as method result
- Properties (utf8 only for now)
